### PR TITLE
friend home, likes in contentRoom

### DIFF
--- a/www/js/controllers/friendHome.js
+++ b/www/js/controllers/friendHome.js
@@ -1,26 +1,160 @@
 'use strict'
 
-app.controller('FriendHomeCtrl', function($scope,Report, Auth, $state, uid, $cordovaScreenshot, SocialShare, Wannas, ImageUpload, FURL, $firebase, $firebaseArray,SharedStateService,$ionicActionSheet,$ionicPopup){
+app.controller('FriendHomeCtrl', function(Message,Match,$scope,Report, Auth, $state, uid, $cordovaScreenshot, SocialShare, Wannas, ImageUpload, FURL, $firebase, $firebaseArray,SharedStateService,$ionicActionSheet,$ionicPopup){
   $scope.friendImages ={'initUid':'initImg'};
   $scope.currentUid=uid;
+  $scope.recommendedImages={};
+  $scope.myFriendsId={};
+  $scope.friendDataStore=0;
+  $scope.clickedFriendId=SharedStateService.clickedFriendId;//SharedStateService からクリックした友人のID を取得
+  $scope.clickedFriendName=SharedStateService.clickedFriendName;//SharedStateService からクリックした友人のID を取得
+  $scope.allWannasList = Wannas.all($scope.clickedFriendId);
+  $scope.showingWannasList = $scope.allWannasList;
+
+
+  var friendNumFlag=20;//フレンドの初期表示人数
   $scope.$watch(function(){
     return SharedStateService.friendImages;
   }, function(){
     $scope.friendImages = SharedStateService.friendImages;
   });
 
-  $scope.clickedFriendId=SharedStateService.clickedFriendId;//SharedStateService からクリックした友人のID を取得
-  $scope.clickedFriendName=SharedStateService.clickedFriendName;//SharedStateService からクリックした友人のID を取得
 
+  $scope.profiles=[{'name':'Loading','$id':'loadingId',}];
 
+  $scope.followOrSendMessage = function(profile){
+    if(profile.icon == 'ion-paper-airplane'){//send messageのアイコンの場合
+        $scope.createRoom(profile.$id);
+    }else if(profile.icon == 'ion-person-add'){//フレンドリクエストアイコンの場合
+        $scope.follow(profile.$id);
+    }
 
-  $scope.allWannasList = Wannas.all($scope.clickedFriendId);
+  };
+
+  $scope.createRoom = function(friend_uid){
+    Message.createNewRoom(uid,friend_uid);
+    $state.go('tab.messages');
+  }
+  $scope.follow = function(follow_uid) {
+      var confirmPopup = $ionicPopup.confirm({
+         title: 'Friend',
+         template: 'Send Friend Request'
+      });
+      confirmPopup.then(function(res) {
+        if(res) {
+          Follow.addFollow(uid, follow_uid);
+          Followed.addFollowed(follow_uid, uid);
+          Match.checkMatch(uid, follow_uid);
+          //$scope.cardRemove(index);
+          console.log("FOLLOW");
+        } else {
+          console.log('You are not sure');
+        }
+      });
+  		//console.log("FOLLOW")
+  },
+
 
   $scope.goContentPage=function(wanna){
     console.log("goContent button was clicked");
     $state.go('tab.wanna-content');
     SharedStateService.clickedWanna=wanna;
     $scope.clickedWanna=wanna;
+  };
+  $scope.messagePopup =function(){
+    $scope.createRoom($scope.clickedFriendId);
+  };
+
+  $scope.referImage = function(profile){
+      console.log('ids',profile.$id);
+      if(profile.blocks){}else{profile.blocks={};}
+      if(uid in profile.blocks){
+        profile.disp={'display':'none'};
+        profile.icon=  'ion-android-alert';
+      }else if(profile.$id == uid){
+        profile.disp={'display':'none'};
+        profile.icon=  'ion-android-alert';
+      }else if(profile.$id in $scope.myFriendsId){
+        profile.icon= 'ion-paper-airplane';
+      }else{
+        profile.icon=  'ion-person-add';
+      }
+      var friendUserId=profile.$id;
+      console.log('refer image fired');
+      if(friendUserId in $scope.recommendedImages){
+      console.log('already gotten recommend');
+      }else{
+      $scope.recommendedImages[friendUserId]='img/loading.png';
+      Wannas.imageAll(friendUserId).$loaded().then(function(images){
+      console.log('got new image');
+      console.log('friendId',friendUserId);
+      if(images[0]==null){console.log('undefined');
+      $scope.recommendedImages[friendUserId]='img/iw_gray.png';
+      }else{
+      $scope.recommendedImages[friendUserId]=images[0]['images'];
+      }
+      },function(error){
+      console.log('oh no! no images file');
+      });
+      }
+  };
+
+  $scope.showFriends=function(){
+      document.getElementById('wannaList').style.display="none";
+      document.getElementById('friendList').style.display="block";
+      Match.allMatchesByUserObject(uid).$loaded().then(function(mydata) {//自分の友人を取得
+          $scope.myFriendsId =mydata;
+          Match.allMatchesByUser($scope.clickedFriendId).$loaded().then(function(data) {
+            $scope.friendDataStore=data;//moreで増やすように一時保管
+            var allFriends=[];
+            if(friendNumFlag>$scope.friendDataStore.length){//フレンドの表示数が実際のデータ長より大きければmoreボタンを消して数をデータ長にfit
+                friendNumFlag=$scope.friendDataStore.length;
+                document.getElementById('moreButton').style.display="none";
+            }
+            for (var i = 0; i < friendNumFlag; i++) {
+                console.log('is',i);
+                var item = data[i];
+                Auth.getUserRelation(item.$id).$loaded().then(function(profile) {
+                allFriends.push(profile);
+              });
+            }
+
+            $scope.profiles =allFriends;
+          });
+      });
+  };
+
+  $scope.moreFriend=function(){
+            friendNumFlag =friendNumFlag+10;//さらに表示する個数をたす。
+            if(friendNumFlag>$scope.friendDataStore.length){
+                friendNumFlag=$scope.friendDataStore.length;
+                document.getElementById('moreButton').style.display="none";
+            }
+            for (var i = $scope.profiles.length; i < friendNumFlag; i++) {
+                console.log('is',i);
+                var item = $scope.friendDataStore[i];
+                Auth.getUserRelation(item.$id).$loaded().then(function(profile) {
+                $scope.profiles.push(profile);
+              });
+            }
+  };
+
+  $scope.defaultWanna= function(){
+      document.getElementById('wannaList').style.display="block";
+      document.getElementById('friendList').style.display="none";
+      $scope.showingWannasList=$scope.allWannasList;
+  };
+
+  $scope.showCompletes= function(){
+      document.getElementById('wannaList').style.display="block";
+      document.getElementById('friendList').style.display="none";
+      var initList=[];
+      for(var i =0;i<$scope.allWannasList.length;i++){
+        if($scope.allWannasList[i].complete==1){
+          initList.push($scope.allWannasList[i]);
+        }
+      }
+      $scope.showingWannasList=initList;
   };
 
 

--- a/www/js/controllers/home.js
+++ b/www/js/controllers/home.js
@@ -51,10 +51,12 @@ app.controller('HomeCtrl', function($scope, Auth, $state, uid, $cordovaScreensho
       $scope.$broadcast('scroll.refreshComplete');
 
   });
-
-
   };
 
+
+  $scope.alertComplete=function(wanna){
+    Wannas.completePopup(wanna);
+  };
 
   // $scope.$on('$ionicView.enter', function(e){
   //   // $scope.show();

--- a/www/js/controllers/searchFriends.js
+++ b/www/js/controllers/searchFriends.js
@@ -97,7 +97,7 @@ app.controller('SearchFriendsCtrl', function($timeout,Wannas,Loading,FURL,$fireb
                         });
                    }
                };
-
+                //上のreferはリコメンド用、以下はフレンドの画像取得用
                $scope.referImage2 = function(friendUserId){
                    console.log('refer image fired');
                    if(friendUserId in $scope.friendImages){

--- a/www/js/controllers/timeline.js
+++ b/www/js/controllers/timeline.js
@@ -1,6 +1,30 @@
 'use strict'
 
 app.controller('DashCtrl', function(uid,usr,$scope,$state,Wannas,SharedStateService,Match,$timeout,FURL, $firebaseArray,Message,Report) {
+//ローカルストレージから情報を取り出す。もしローカルが利用できない場合やまだ情報がない場合はFirebaseから情報を落として保管。
+// localStorageが使用出来るかチェック
+if (!window.localStorage) {
+    console.log("no LocalStorage");
+}else{
+    console.log("Use LocalStorage");
+};
+
+// localStorageに値を保存
+function setItem(key, val) {
+    window.localStorage.setItem(key, val);
+};
+setItem(uid,true);
+// localStorageから値を取得
+function getItem(key) {
+    return window.localStorage.getItem(key);
+};
+var storage= getItem(uid);
+console.log(storage);
+//ローカルストレージのイニシャライズ終わり
+//これらをserviceファイル にしよう。
+//参考http://qiita.com/ichikawa_0829/items/85413fedc59822ccef75
+
+
                //ログインする前に uid を参照しようとするとエラーとなるので注意。
                //エラー処理については http://uhyohyo.net/javascript/9_8.html
                //ログインする前にuid は使えないので、エラー処理を入れた。(結局、抜いた)

--- a/www/js/controllers/wannaContent.js
+++ b/www/js/controllers/wannaContent.js
@@ -7,11 +7,21 @@ app.controller('WannaContentCtrl', function(uid,$scope,$state,SharedStateService
                var likedUsersId=$scope.clickedWanna.likes;
                var idArray=[];
                var roomList = [];
+               var friendNumFlag=5;//likeした人の初期表示数。
                for(var key in likedUsersId){
-                   idArray.push(key);
+                   console.log('liked User',key);
+                   idArray.push({'$id':key});
                };
-               $scope.likedUsers=[];
+               idArray.pop();//initial valueの消去。popの返り値は削除した値になるので注意。idArrayは一つ削られた配列に変化する。
 
+               if(idArray.length<friendNumFlag){//制限個数より少ない時
+                 friendNumFlag=idArray.length;//制限個数を配列個数に縮小
+                 //ボタンの非表示
+                 document.getElementById('moreButton').style.display="none";
+               }
+               $scope.likedUsers=idArray.slice(0,friendNumFlag);//表示個数制限
+
+               $scope.unknownImages={};
                console.log("ContentPage",$scope.clickedWanna.content);
                $scope.friendImages ={'initUid':'initImg'};
                var currentUid=uid;
@@ -31,31 +41,66 @@ app.controller('WannaContentCtrl', function(uid,$scope,$state,SharedStateService
                 }
                });
 
-               $scope.extract=function(idArray){
-                    if(idArray.length>1){
-                    var oneID=idArray[0];//ひとつ目のライクした人のid を取得
-                    Wannas.getObjectUserName(oneID).$loaded().then(function(obj){
-                      var name = obj.$value;
-                      console.log('name',name);
-                      if(name){
-                         console.log('Writing');
-                         $scope.likedUsers.push({'name': name,
-                         'id': oneID});
-                         idArray.shift();//ひとつめを削除
-                         console.log('idArray',idArray);
-                         $scope.extract(idArray);//減ったidArrayでまた始める
-                      }
+
+               $scope.moreFriend=function(){
+                        friendNumFlag =friendNumFlag+10;//さらに表示する個数をたす。
+                        if(friendNumFlag>idArray.length){
+                            friendNumFlag=idArray.length;
+                            document.getElementById('moreButton').style.display="none";
+                        }
+                        $scope.likedUsers=idArray.slice(0,friendNumFlag);//表示個数制限
+               };
+
+
+//               $scope.extract=function(idArray){
+//                    if(idArray.length>1){
+//                    var oneID=idArray[0];//ひとつ目のライクした人のid を取得
+//                    Wannas.getObjectUserName(oneID).$loaded().then(function(obj){
+//                      var name = obj.$value;
+//                      console.log('name',name);
+//                      if(name){
+//                         console.log('Writing');
+//                         $scope.likedUsers.push({'name': name,
+//                         'id': oneID});
+//                         idArray.shift();//ひとつめを削除
+//                         console.log('idArray',idArray);
+//                         $scope.extract(idArray);//減ったidArrayでまた始める
+//                      }
+//                    });
+//                    }else{
+//                        console.log('end of like users');
+//                    }
+//               };
+//               $scope.extract(idArray);
+               $scope.getName=function(user){
+                    console.log('get name fired');
+                    Wannas.getObjectUserName(user.$id).$loaded().then(function(obj){
+                      user['name'] = obj.$value;
                     });
-                    }else{
-                        console.log('end of like users');
-                    }
+                      if(user.id in $scope.unknownImages){
+                      console.log('already gotten recommend');
+                      }else{
+                      $scope.unknownImages[user.$id]='img/loading.png';
+                      Wannas.imageAll(user.$id).$loaded().then(function(images){
+                          console.log('got new image');
+                          if(images[0]==null){console.log('undefined');
+                              $scope.unknownImages[user.$id]='img/iw_gray.png';
+                          }else{
+                              $scope.unknownImages[user.$id]=images[0]['images'];
+                          }
+                      },function(error){
+                      console.log('oh no! no images file');
+                      });
+                      }
                };
 
                $scope.showLikedUsers=function(){
-                 $scope.extract(idArray);
-                 console.log('show liked users');
-//                 var likeBoard=document.getElementById('likeBoard');
-//                 likeBoard.style.visibility="visible";
+                 if(document.getElementById('likeBoard').style.display=='none'){
+                     console.log('show liked users');
+                     document.getElementById('likeBoard').style.display='block';
+                 }else{
+                     document.getElementById('likeBoard').style.display='none';
+                 }
                }
 
                $scope.date = function(dayInt){

--- a/www/js/services/auth.js
+++ b/www/js/services/auth.js
@@ -42,6 +42,10 @@ app.factory('Auth', function(FURL, $firebaseAuth, $firebaseObject, $state, $fire
       return $firebaseArray(ref.child('relationships'));
     },
 
+    getUserRelation: function(friendUid){
+      return $firebaseObject(ref.child('relationships').child(friendUid));
+    },
+
 
 
     login: function(user){

--- a/www/js/services/match.js
+++ b/www/js/services/match.js
@@ -1,6 +1,6 @@
 'use strict';
 
-app.factory('Match', function(FURL, $firebaseArray) {
+app.factory('Match', function(FURL, $firebaseArray,$firebaseObject) {
 	var ref = new Firebase(FURL);
 
 	var Match = {
@@ -9,7 +9,13 @@ app.factory('Match', function(FURL, $firebaseArray) {
 
 			return $firebaseArray(ref.child('matches').child(uid));
 		},
-		
+
+		allMatchesByUserObject: function(uid) {//オブジェクト版も追加した
+
+			return $firebaseObject(ref.child('matches').child(uid));
+		},
+
+
 		checkMatch: function(uid1,uid2) {
 			var check = ref.child('follows').child(uid2).child(uid1);
 

--- a/www/js/services/message.js
+++ b/www/js/services/message.js
@@ -24,26 +24,29 @@ app.factory('Message', function(FURL, $firebaseArray, $firebaseObject, Auth, Wan
                         console.log('roomId is',roomId);
                         var user1 = $firebaseArray(ref.child('users').child(uid1).child('rooms'));
                         var user2 = $firebaseArray(ref.child('users').child(uid2).child('rooms'));
-                        
-                        var newRoom1 = {
-                          roomId: roomId,
-                          friendId: uid2, 
-                          friendName: Wannas.getUserName(uid2)
 
-                        };
+                        Wannas.getObjectUserName(uid2).$loaded().then(function(obj2){
+                            var userName2=obj2.$value;
+                            var newRoom1 = {
+                              roomId: roomId,
+                              friendId: uid2,
+                              friendName: userName2,
+                            };
 
 
-                        return user1.$add(newRoom1).then(function(){
-                          var newRoom2 = {
-                          roomId: roomId,
-                          friendId: uid1,
-                          friendName: Wannas.getUserName(uid1)
-
-                        };
-                          return user2.$add(newRoom2);
-
+                            return user1.$add(newRoom1).then(function(){
+                              Wannas.getObjectUserName(uid1).$loaded().then(function(obj1){
+                                var userName1=obj1.$value;
+                                var newRoom2 = {
+                                roomId: roomId,
+                                friendId: uid1,
+                                friendName: userName1,
+                                };
+                                return user2.$add(newRoom2);
+                              });
+                            });
                         });
-                        
+
                         
 
                       });

--- a/www/js/services/submitWanna.js
+++ b/www/js/services/submitWanna.js
@@ -1,6 +1,6 @@
 'use strict'
 
-app.factory('Wannas', function(FURL,$firebaseObject, $firebaseArray) {
+app.factory('Wannas', function(FURL,$firebaseObject, $firebaseArray,$ionicPopup) {
 
               var ref =new Firebase(FURL);
 //              var wannas = $firebaseArray(ref.child('facebookuser').child('wannas'));//firebase構造によって変えてみてください。
@@ -153,6 +153,43 @@ app.factory('Wannas', function(FURL,$firebaseObject, $firebaseArray) {
 //                   $scope.wannas=data;//表示するやつをdata に同期
                    console.log("users likes",likedWannaId);
                    return likedWannaId;
+                 },
+
+                 completePopup:function(wanna){
+                      var myPopup = $ionicPopup.show({
+                        template: '<p style="color:#777777 ">このWannaを達成しましたか？</p>',
+                        title: 'Complete',
+//                        subTitle: 'Please use normal things',
+                        buttons: [
+                          { text: 'Cancel' },
+                          {
+                            text: '<b>達成した！</b>',
+                            type: 'button-energized',
+                            onTap: function(e) {
+                                ref.child('users').child(wanna.ownerId).child('wannas').child(wanna.$id).child('complete').set(1);
+                                ref.child('users').child(wanna.ownerId).child('wannas').child(wanna.$id).child('icon').child(0).set('ion-android-star-outline');//('ion-ribbon-b');//('ion-ios-star-outline');
+                                  var congratulation = $ionicPopup.show({
+                                    template: '<p style="color:#777777 ">あなたのWannaは達成されました。</p>',//<p style="color:#777777 ">このWannaが素敵な思い出となり、あなたの未来をより豊かにしてくれますことを願っています。</p>',
+                                    title: 'おめでとうございます',
+            //                        subTitle: 'Please use normal things',
+                                    buttons: [
+                                      {
+                                        text: 'OK',
+                                        type: 'button-energized',
+                                      }
+                                    ]
+                                  });
+                            }
+                          }
+                        ]
+                      });
+
+                      myPopup.then(function(res) {
+                        console.log('Tapped!', res);
+                      });
+//                      $timeout(function() {
+//                         myPopup.close(); //close the popup after 3 seconds for some reason
+//                      }, 3000);
                  },
 
                  getColor:function(mot){//0 から100 の数字でカラーを返す

--- a/www/templates/friend-home.html
+++ b/www/templates/friend-home.html
@@ -3,15 +3,23 @@
     <a class="button button-icon icon ion-more" ng-click="report(clickedFriendName,clickedFriendId)" style="color:#ffffff"></a>
   </ion-nav-buttons>
   <ion-content>
-      <div class="list">
-        <a class="item item-avatar">
+      <!--<div class="list">-->
+        <a class="item item-avatar" ng-click="defaultWanna()">
         <img data-ng-src={{friendImages[clickedFriendId]}}>
         {{clickedFriendName}}
         <p> all Wannas List </p>
         </a>
-      </div>
-    <ion-list>
-      <ion-item class="item-remove-animate item-avatar item-icon-right" ng-repeat="wanna in allWannasList" type="item-text-wrap" >
+      <!--</div>-->
+    <div class="button-bar">
+      <a class="button" ng-click="showCompletes()"><i class="icon ion-ios-star"></i></a>
+      <a class="button" ng-click="showFriends()"><i class="icon ion-person-stalker"></i></a>
+      <a class="button" ng-click="messagePopup()"><i class="icon ion-paper-airplane"></i></a>
+    </div>
+
+
+    <!--wannaの表示用-->
+    <ion-list id="wannaList" style="display:block">
+      <ion-item class="item-remove-animate item-avatar item-icon-right" ng-repeat="wanna in showingWannasList" type="item-text-wrap" >
         <i class = {{wanna.icon[0]}} style=" color:{{wanna.color}};"></i>
         <h2 ng-Click="goContentPage(wanna)">{{wanna.content}}</h2>
         <p ng-Click="goContentPage(wanna)">{{wanna.description}}</p>
@@ -20,9 +28,24 @@
         <!--</ion-option-button>-->
       </ion-item>
     </ion-list>
-  </ion-content>
-</ion-view>
 
+    <div id="friendList" style="display:none">
+      <div class="list card" ng-repeat="profile in profiles" ng-init="referImage(profile)">
+
+        <div class="item item-button-right">
+          <img data-ng-src={{recommendedImages[profile.$id]}} style="height:40px ; width:40px; border-radius: 200px">
+          {{profile.name}}
+          <!--{{profile.uid}}-->
+          <button class="button button-calm" ng-click = "followOrSendMessage(profile)" ng-style="profile.disp">
+            <i class="{{profile.icon}}"></i>
+          </button>
+        </div>
+
+      </div>
+      <button id="moreButton" class="button button-block button-stable" ng-click = "moreFriend()">
+        Watch More
+      </button>
+    </div>
 
 
   </ion-content>

--- a/www/templates/tab-home.html
+++ b/www/templates/tab-home.html
@@ -19,7 +19,7 @@
     </div>
     <ion-list>
       <ion-item class="item-remove-animate item-avatar item-icon-right" ng-repeat="wanna in allWannasList" type="item-text-wrap" >
-        <i class = {{wanna.icon[0]}} style=" color:{{wanna.color}};" ng-Click="goContentPage(wanna)"></i>
+        <i class = {{wanna.icon[0]}} style=" color:{{wanna.color}};" ng-Click="goContentPage(wanna)" on-hold="alertComplete(wanna)"></i>
         <h2 ng-Click="goContentPage(wanna)">{{wanna.content}}</h2>
         <p ng-Click="goContentPage(wanna)">{{wanna.description}}</p>
         <ion-option-button class="button-assertive" ng-click="removeWanna($index , wanna.ownerId, wanna.$id,wanna.likes)">
@@ -28,7 +28,7 @@
       </ion-item>
     </ion-list>
 
-    <div class="item item-divider">
+    <div class="item item-divider" style="background-color:rgb(255, 192, 203)">
       My Likes
     </div>
     <ion-list>

--- a/www/templates/tab-messages.html
+++ b/www/templates/tab-messages.html
@@ -6,7 +6,7 @@
         <h2>{{room.friendName}}</h2>
         <i class="icon ion-chevron-right icon-accessory"></i>
 
-        <ion-option-button class="button-assertive" ng-click="remove(chat)">
+        <ion-option-button class="button-assertive" ng-click="remove(room.roomId)">
           Delete
         </ion-option-button>
       </ion-item>

--- a/www/templates/wanna-content.html
+++ b/www/templates/wanna-content.html
@@ -23,12 +23,22 @@
              <button id="likeInContent" style="color:#bbbbbb; background-color: #ffffff; width : 50px;" type="button" class="button icon ion-heart" ng-init="colorTheLikes(clickedWanna)" ng-Click="likeWannaInContent(clickedWanna)"></button>
     </div>
   </div>
-      <div class="list" id="likeBoard" style="visibility:visible" ng-repeat="user in likedUsers">
-          <a class="item item-avatar" href="#">
-              <img data-ng-src={{friendImages[user.id]}}>
-              <p>{{user.name}}</p>
-          </a>
-
+        <!--<p>{{likedUsers}}</p>-->
+      <div id="likeBoard" style="display:none">
+          <div class="item item-divider">
+              {{likeNum}} Users Liked
+          </div>
+          <br>
+            <!--ng-repeatの表示、非表示をやるときは、ひとつ上のdivなどでdisplay:none block を切り替えなければならない。じゃないと、repeatの一つだけしかコントロールできない-->
+          <div class="list" ng-repeat="user in likedUsers" ng-init="getName(user)">
+              <div class="item item-avatar">
+                  <img data-ng-src={{unknownImages[user.$id]}}>
+                  <p>{{user.name}}</p>
+              </div>
+          </div>
+          <button id="moreButton" class="button button-block button-stable" ng-click = "moreFriend()">
+              Watch More
+          </button>
       </div>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
フレンドのホームでその友人を確認できるように。(フレンドタブではまだ未対応)
フレンドのホームでその友人にリクエストを送れるように。(フレンドタブではまだ未対応)
メッセージルーム遷移ボタンを追加。(フレンドタブではまだ未対応)

wannaContentでLike Usersを閉じられるように。
wannaContentでライクした人の画像を取得できるように。(フレンドタブではまだ未対応)

messageRoomを作成する時の名前取得エラーを修正。

自分のホームでのWannaの達成属性の付与。
